### PR TITLE
additional output options

### DIFF
--- a/doc/example/test_mtssl.sh
+++ b/doc/example/test_mtssl.sh
@@ -9,9 +9,17 @@ if [ "`which convolve-mtss-rotamers.py`" = "" ]; then
     echo "Install the package first with 'python setip.py install --user' from the top dir"
     exit 2
 fi
-convolve-mtss-rotamers.py --resid 47 330  --histogramBins 0 80 1  --clashDistance 2.2  \
-          --output "dat/peptso-xrd"  --dcdfilename "dcd/peptso-xrd-47-330" \
-          peptso.gro 
+
+convolve-mtss-rotamers.py \
+    --resid 47 330  \
+    --histogramBins 0 80 1  \
+    --clashDistance 2.2  \
+    --outputHistogram "dat/peptso-xrd" \
+    --plotname "dat/peptso-xrd.pdf" \
+    --outputRawDistances "dat/peptso-xrd-RawDistances" \
+    --dcdfilenameAll "dcd/peptso-xrd-47-330" \
+    --dcdfilenameNoClashes "dcd/peptso-xrd-47-330" \
+    peptso.gro 
 
 diff reference/peptso-xrd-47-330.dat dat/peptso-xrd-47-330.dat
 test $? -eq 0 && echo "Test PASSED" || echo "Test FAILED."

--- a/doc/example/test_mtssl.sh
+++ b/doc/example/test_mtssl.sh
@@ -16,10 +16,10 @@ convolve-mtss-rotamers.py \
     --clashDistance 2.2  \
     --output "dat/peptso-xrd" \
     --plotname "dat/peptso-xrd.pdf" \
-    --outputRawDistances "dat/peptso-xrd-47-330" \
-    --dcdfilenameAll "dcd/peptso-xrd-47-330" \
-    --dcdfilenameNoClashes "dcd/peptso-xrd-47-330" \
+    --outputRawDistances "dat/peptso-xrd" \
+    --dcdfilename "dcd/peptso-xrd" \
+    --dcdfilenameNoClashes "dcd/peptso-xrd" \
     peptso.gro 
 
-diff reference/peptso-xrd-47-330.dat dat/peptso-xrd-47-330-histogram.dat
+diff reference/peptso-xrd-47-330.dat dat/peptso-xrd-47-330.dat
 test $? -eq 0 && echo "Test PASSED" || echo "Test FAILED."

--- a/doc/example/test_mtssl.sh
+++ b/doc/example/test_mtssl.sh
@@ -14,12 +14,12 @@ convolve-mtss-rotamers.py \
     --resid 47 330  \
     --histogramBins 0 80 1  \
     --clashDistance 2.2  \
-    --outputHistogram "dat/peptso-xrd" \
+    --output "dat/peptso-xrd" \
     --plotname "dat/peptso-xrd.pdf" \
-    --outputRawDistances "dat/peptso-xrd-RawDistances" \
+    --outputRawDistances "dat/peptso-xrd-47-330" \
     --dcdfilenameAll "dcd/peptso-xrd-47-330" \
     --dcdfilenameNoClashes "dcd/peptso-xrd-47-330" \
     peptso.gro 
 
-diff reference/peptso-xrd-47-330.dat dat/peptso-xrd-47-330.dat
+diff reference/peptso-xrd-47-330.dat dat/peptso-xrd-47-330-histogram.dat
 test $? -eq 0 && echo "Test PASSED" || echo "Test FAILED."

--- a/rotcon/convolve.py
+++ b/rotcon/convolve.py
@@ -114,22 +114,26 @@ class RotamerDistances(object):
             rotamer1nitrogen = rotamersSite1.select_atoms("name N1")
             rotamer2nitrogen = rotamersSite2.select_atoms("name N1")
 
-            # loop over all the rotamers on the first site
-            for rotamer1 in rotamersSite1.trajectory:
-                if not rotamer1_clash[rotamer1.frame]:
-                    # loop over all the rotamers on the second site
-                    for rotamer2 in rotamersSite2.trajectory:
-                        if not rotamer2_clash[rotamer2.frame]:
-                            # measure and record the distance
-                            (a, b, distance) = MDAnalysis.analysis.distances.dist(rotamer1nitrogen, rotamer2nitrogen)
-                            distances.append(distance[0])
-                            # create the weights list
-                            try:
-                                weight = self.lib.weights[rotamer1.frame] * self.lib.weights[rotamer2.frame]
-                            except IndexError:
-                                logger.error("oppps: no weights for rotamer 1 #{0} - "
-                                             "rotamer 2 #{1}".format(rotamer1.frame, rotamer2.frame))
-                            weights.append(weight)
+            with MDAnalysis.Writer("sit1.pdb", rotamersSite1.n_atoms) as S1:
+                with MDAnalysis.Writer("sit2.pdb", rotamersSite2.n_atoms) as S2:
+                    # loop over all the rotamers on the first site
+                    for rotamer1 in rotamersSite1.trajectory:
+                        if not rotamer1_clash[rotamer1.frame]:
+                            # loop over all the rotamers on the second site
+                            for rotamer2 in rotamersSite2.trajectory:
+                                if not rotamer2_clash[rotamer2.frame]:
+                                    S1.write(rotamersSite1.atoms)
+                                    S2.write(rotamersSite2.atoms)
+                                    # measure and record the distance
+                                    (a, b, distance) = MDAnalysis.analysis.distances.dist(rotamer1nitrogen, rotamer2nitrogen)
+                                    distances.append(distance[0])
+                                    # create the weights list
+                                    try:
+                                        weight = self.lib.weights[rotamer1.frame] * self.lib.weights[rotamer2.frame]
+                                    except IndexError:
+                                        logger.error("oppps: no weights for rotamer 1 #{0} - "
+                                                    "rotamer 2 #{1}".format(rotamer1.frame, rotamer2.frame))
+                                    weights.append(weight)
 
         # check that at least two distances have been measured
         if len(distances) < 2:

--- a/rotcon/convolve.py
+++ b/rotcon/convolve.py
@@ -73,23 +73,23 @@ class RotamerDistances(object):
 
         outputFileHistogram, ext = os.path.splitext(kwargs.pop('outputFileHistogram', 'distances'))
         ext = ext or ".dat"
-        self.outputFileHistogram = "{0}-{1[0]}-{1[1]}{2}".format(outputFileHistogram, residues, ext)
+        self.outputFileHistogram = "{0}-{1[0]}-{1[1]}-histogram{2}".format(outputFileHistogram, residues, ext)
 
         outputFileRawDistances, ext = os.path.splitext(kwargs.pop('outputFileRawDistances', 'distances'))
         ext = ext or ".dat"
-        self.outputFileRawDistances = "{0}-{1[0]}-{1[1]}{2}".format(outputFileRawDistances, residues, ext)
+        self.outputFileRawDistances = "{0}-{1[0]}-{1[1]}-rawDistances{2}".format(outputFileRawDistances, residues, ext)
         
         
         dcdFilenameAll, ext = os.path.splitext(kwargs.pop('dcdFilenameAll', 'trj'))
         ext = ext or ".dcd"
-        tmptrj = ["{0}-1{1}".format(dcdFilenameAll, ext),  # or make this temp files?
-                  "{0}-2{1}".format(dcdFilenameAll, ext),  # or make this temp files?
+        tmptrj = ["{0}-{1[0]}-{1[1]}-all-1{2}".format(dcdFilenameAll, residues, ext),  # or make this temp files?
+                  "{0}-{1[0]}-{1[1]}-all-2{2}".format(dcdFilenameAll, residues, ext),  # or make this temp files?
                   ]
         
         dcdFilenameNoClashes, ext = os.path.splitext(kwargs.pop('dcdFilenameNoClashes', 'trj'))
         ext = ext or ".dcd"
-        tmptrjNoClashes = ["{0}-rawDistances-1{1}".format(dcdFilenameNoClashes, ext),  # or make this temp files?
-                           "{0}-rawDistances-2{1}".format(dcdFilenameNoClashes, ext),  # or make this temp files?
+        tmptrjNoClashes = ["{0}-{1[0]}-{1[1]}-noClashes-1{2}".format(dcdFilenameNoClashes, residues, ext),  # or make this temp files?
+                           "{0}-{1[0]}-{1[1]}-noClashes-2{2}".format(dcdFilenameNoClashes, residues, ext),  # or make this temp files?
                           ]
 
 

--- a/rotcon/convolve.py
+++ b/rotcon/convolve.py
@@ -41,7 +41,7 @@ class RotamerDistances(object):
               the labelled sites
 
         :Keywords:
-           *dcdFilenameAll*
+           *dcdFilename*
               name of the temporary files with rotamers fitted [``'trj'``]
            *dcdFilenameNoClashes*
               name of the temporary files with rotamers fitted [``'trj'``]
@@ -73,17 +73,17 @@ class RotamerDistances(object):
 
         outputFile, ext = os.path.splitext(kwargs.pop('outputFile', 'distances'))
         ext = ext or ".dat"
-        self.outputFile = "{0}-{1[0]}-{1[1]}-histogram{2}".format(outputFile, residues, ext)
+        self.outputFile = "{0}-{1[0]}-{1[1]}{2}".format(outputFile, residues, ext)
 
         outputFileRawDistances, ext = os.path.splitext(kwargs.pop('outputFileRawDistances', 'distances'))
         ext = ext or ".dat"
         self.outputFileRawDistances = "{0}-{1[0]}-{1[1]}-rawDistances{2}".format(outputFileRawDistances, residues, ext)
         
         
-        dcdFilenameAll, ext = os.path.splitext(kwargs.pop('dcdFilenameAll', 'trj'))
+        dcdFilename, ext = os.path.splitext(kwargs.pop('dcdFilename', 'trj'))
         ext = ext or ".dcd"
-        tmptrj = ["{0}-{1[0]}-{1[1]}-all-1{2}".format(dcdFilenameAll, residues, ext),  # or make this temp files?
-                  "{0}-{1[0]}-{1[1]}-all-2{2}".format(dcdFilenameAll, residues, ext),  # or make this temp files?
+        tmptrj = ["{0}-{1[0]}-{1[1]}-1{2}".format(dcdFilename, residues, ext),  # or make this temp files?
+                  "{0}-{1[0]}-{1[1]}-2{2}".format(dcdFilename, residues, ext),  # or make this temp files?
                   ]
         
         dcdFilenameNoClashes, ext = os.path.splitext(kwargs.pop('dcdFilenameNoClashes', 'trj'))

--- a/rotcon/convolve.py
+++ b/rotcon/convolve.py
@@ -45,7 +45,7 @@ class RotamerDistances(object):
               name of the temporary files with rotamers fitted [``'trj'``]
            *dcdFilenameNoClashes*
               name of the temporary files with rotamers fitted [``'trj'``]
-           *outputFileHistogram*
+           *outputFile*
               stem of the name of the file containing the distance histogram
               (the final name will be ``<outputFile><resid_1>-<resid_2>.dat``
               [``'distances'``]
@@ -71,9 +71,9 @@ class RotamerDistances(object):
             raise ValueError("The residue_list must contain exactly 2 residue numbers: current "
                              "value {0}.".format(residues))
 
-        outputFileHistogram, ext = os.path.splitext(kwargs.pop('outputFileHistogram', 'distances'))
+        outputFile, ext = os.path.splitext(kwargs.pop('outputFile', 'distances'))
         ext = ext or ".dat"
-        self.outputFileHistogram = "{0}-{1[0]}-{1[1]}-histogram{2}".format(outputFileHistogram, residues, ext)
+        self.outputFile = "{0}-{1[0]}-{1[1]}-histogram{2}".format(outputFile, residues, ext)
 
         outputFileRawDistances, ext = os.path.splitext(kwargs.pop('outputFileRawDistances', 'distances'))
         ext = ext or ".dat"
@@ -108,7 +108,7 @@ class RotamerDistances(object):
         logger.info("clashDistance = {0} A; rotamer library = '{1}'".format(self.clashDistance, self.lib.name))
         logger.debug("Temporary trajectories for rotamers 1 and 2 "
                      "(only last frame of MD trajectory): {0[0]} and {0[1]}".format(tmptrj))
-        logger.debug("Results will be written to {0}.".format(self.outputFileHistogram))
+        logger.debug("Results will be written to {0}.".format(self.outputFile))
 
         progressmeter = MDAnalysis.log.ProgressMeter(proteinStructure.trajectory.n_frames, interval=1)
         for protein in proteinStructure.trajectory:
@@ -170,11 +170,11 @@ class RotamerDistances(object):
         (a, b) = np.histogram(distances, weights=weights, density=True, bins=bins['Nbins'],
                               range=(bins['min'], bins['max']))
 
-        with open(self.outputFileHistogram, 'w') as OUTPUT:
+        with open(self.outputFile, 'w') as OUTPUT:
             for (i, j) in enumerate(a):
                 OUTPUT.write("%6.2f %8.3e\n" % ((0.5*(b[i] + b[i+1])), j))
         logger.info("Distance distribution for residues {0[0]} - {0[1]} "
-                    "was written to {1}".format(residues, self.outputFileHistogram))
+                    "was written to {1}".format(residues, self.outputFile))
         
         with open(self.outputFileRawDistances, 'w') as OUTPUT:
             for distance in distances:
@@ -192,7 +192,7 @@ class RotamerDistances(object):
         if ax is None:
             ax = fig.add_subplot(111)
 
-        dist, prob = np.loadtxt(self.outputFileHistogram, unpack=True)
+        dist, prob = np.loadtxt(self.outputFile, unpack=True)
         ax.plot(dist, prob, **kwargs)
         ax.set_xlabel(r"spin-label distance $d$ ($\AA$)")
         ax.set_ylabel("probability density")

--- a/scripts/convolve-mtss-rotamers.py
+++ b/scripts/convolve-mtss-rotamers.py
@@ -47,11 +47,17 @@ if __name__ == "__main__":
         parser.add_option("--clashDistance", dest="clashDistance", type=float, default=2.2,
                           help="the distance between heavy-atoms of the label and protein within which "
                                "they are assumed to be clashing [%default Angstroms]")
-        parser.add_option("--output", dest="outputFile", default="output.dat",
+        parser.add_option("--outputHistogram", dest="outputFileHistogram", default="output.dat",
                           help="the path and name of the output histogram file; the filename will "
                                "have resid 1 and resid 2 inserted before the extension [%default]")
-        parser.add_option("--dcdfilename", dest="dcdFilename", metavar="FILENAME",
+        parser.add_option("--outputRawDistances", dest="outputFileRawDistances", default="outputRawDistances.dat",
+                          help="the path and name of the output file with raw distances; the filename will "
+                               "have resid 1 and resid 2 inserted before the extension [%default]")
+        parser.add_option("--dcdfilenameAll", dest="dcdFilenameAll", metavar="FILENAME",
                           help="the path and stem of the DCD files of the fitted MTSS rotamers")
+        parser.add_option("--dcdfilenameNoClashes", dest="dcdFilenameNoClashes", metavar="FILENAME",
+                          help="the path and stem of the DCD files of the fitted MTSS rotamers "
+                               " without clashes")
         parser.add_option("--libname", dest="libname", metavar="NAME", default="MTSSL 298K",
                           help="name of the rotamer library [%default]")
         parser.add_option("--plotname", dest="plotname", metavar="FILENAME", default=None,
@@ -78,13 +84,16 @@ if __name__ == "__main__":
 
         logger.info("Loading trajectory data as Universe({0})".format(*args))
 
-        if not options.dcdFilename:
-                options.dcdFilename = options.outputFile + "-tmp"
+        if not options.dcdFilenameAll:
+                options.dcdFilenameAll = options.outputFileHistogram + "-tmp"
 
         startTime = time.time()
         R = rotcon.convolve.RotamerDistances(proteinStructure,
                                              options.residues,
-                                             outputFile=options.outputFile, dcdFilename=options.dcdFilename,
+                                             outputFileHistogram=options.outputFileHistogram, 
+                                             outputFileRawDistances=options.outputFileRawDistances, 
+                                             dcdFilenameAll=options.dcdFilenameAll,
+                                             dcdFilenameNoClashes=options.dcdFilenameNoClashes,
                                              libname=options.libname, discardFrames=options.discardFrames,
                                              clashDistance=options.clashDistance,
                                              histogramBins=options.histogramBins)

--- a/scripts/convolve-mtss-rotamers.py
+++ b/scripts/convolve-mtss-rotamers.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         parser.add_option("--outputRawDistances", dest="outputFileRawDistances", default="outputRawDistances.dat",
                           help="the path and name of the output file with raw distances; the filename will "
                                "have resid 1 and resid 2 inserted before the extension [%default]")
-        parser.add_option("--dcdfilenameAll", dest="dcdFilenameAll", metavar="FILENAME",
+        parser.add_option("--dcdfilename", dest="dcdFilename", metavar="FILENAME",
                           help="the path and stem of the DCD files of the fitted MTSS rotamers")
         parser.add_option("--dcdfilenameNoClashes", dest="dcdFilenameNoClashes", metavar="FILENAME",
                           help="the path and stem of the DCD files of the fitted MTSS rotamers "
@@ -84,15 +84,15 @@ if __name__ == "__main__":
 
         logger.info("Loading trajectory data as Universe({0})".format(*args))
 
-        if not options.dcdFilenameAll:
-                options.dcdFilenameAll = options.outputFile + "-tmp"
+        if not options.dcdFilename:
+                options.dcdFilename = options.outputFile + "-tmp"
 
         startTime = time.time()
         R = rotcon.convolve.RotamerDistances(proteinStructure,
                                              options.residues,
                                              outputFile=options.outputFile, 
                                              outputFileRawDistances=options.outputFileRawDistances, 
-                                             dcdFilenameAll=options.dcdFilenameAll,
+                                             dcdFilename=options.dcdFilename,
                                              dcdFilenameNoClashes=options.dcdFilenameNoClashes,
                                              libname=options.libname, 
                                              discardFrames=options.discardFrames,

--- a/scripts/convolve-mtss-rotamers.py
+++ b/scripts/convolve-mtss-rotamers.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         parser.add_option("--clashDistance", dest="clashDistance", type=float, default=2.2,
                           help="the distance between heavy-atoms of the label and protein within which "
                                "they are assumed to be clashing [%default Angstroms]")
-        parser.add_option("--outputHistogram", dest="outputFileHistogram", default="output.dat",
+        parser.add_option("--output", dest="outputFile", default="output.dat",
                           help="the path and name of the output histogram file; the filename will "
                                "have resid 1 and resid 2 inserted before the extension [%default]")
         parser.add_option("--outputRawDistances", dest="outputFileRawDistances", default="outputRawDistances.dat",
@@ -57,7 +57,7 @@ if __name__ == "__main__":
                           help="the path and stem of the DCD files of the fitted MTSS rotamers")
         parser.add_option("--dcdfilenameNoClashes", dest="dcdFilenameNoClashes", metavar="FILENAME",
                           help="the path and stem of the DCD files of the fitted MTSS rotamers "
-                               " without clashes")
+                               "without clashes")
         parser.add_option("--libname", dest="libname", metavar="NAME", default="MTSSL 298K",
                           help="name of the rotamer library [%default]")
         parser.add_option("--plotname", dest="plotname", metavar="FILENAME", default=None,
@@ -85,16 +85,17 @@ if __name__ == "__main__":
         logger.info("Loading trajectory data as Universe({0})".format(*args))
 
         if not options.dcdFilenameAll:
-                options.dcdFilenameAll = options.outputFileHistogram + "-tmp"
+                options.dcdFilenameAll = options.outputFile + "-tmp"
 
         startTime = time.time()
         R = rotcon.convolve.RotamerDistances(proteinStructure,
                                              options.residues,
-                                             outputFileHistogram=options.outputFileHistogram, 
+                                             outputFile=options.outputFile, 
                                              outputFileRawDistances=options.outputFileRawDistances, 
                                              dcdFilenameAll=options.dcdFilenameAll,
                                              dcdFilenameNoClashes=options.dcdFilenameNoClashes,
-                                             libname=options.libname, discardFrames=options.discardFrames,
+                                             libname=options.libname, 
+                                             discardFrames=options.discardFrames,
                                              clashDistance=options.clashDistance,
                                              histogramBins=options.histogramBins)
         logger.info("DONE with analysis, elapsed time %6i s" % (int(time.time() - startTime)))


### PR DESCRIPTION
In the updated version, two new flags are added to get an output file with the raw distances and two other rotamer trajectories without clashes. These flags would help future users to validate their work. Further, it might be the basis for a new unit test.
The attached figures shows the non clashing trajectories of MTSL with the example protein. The previous figures might have been misleading as all rotamers in the trajectories were saved (not only non-chlasing trajectories can be loaded for visualization).
Still, the example/reference is different due to the change in the indexing. This is kept for the moment.
![peptso3](https://cloud.githubusercontent.com/assets/5737025/14983305/afdb993c-113c-11e6-95db-564f00549ced.png)
